### PR TITLE
Remove linter warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "A directory favorite tool in rust"
 repository = "https://github.com/Index197511/diar"
 readme = "README.md"
-keyword = ["directory", "bookmark", "rust"]
+keywords = ["directory", "bookmark", "rust"]
 
 [dependencies]
 sled = "0.27"

--- a/src/add/mod.rs
+++ b/src/add/mod.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use diar::util::print_done_if_ok;
 
-pub fn add_favorite(maybe_path_given: Option<&Path>, key: String, db_path: &Path) -> () {
+pub fn add_favorite(maybe_path_given: Option<&Path>, key: String, db_path: &Path) {
     let db = Db::open(db_path).unwrap();
     match db.get(&key) {
         Ok(Some(_)) => {
@@ -25,11 +25,11 @@ pub fn add_favorite(maybe_path_given: Option<&Path>, key: String, db_path: &Path
     }
 }
 
-fn add_path_to_db(path: &Path, key: String, db: sled::Db) -> () {
+fn add_path_to_db(path: &Path, key: String, db: sled::Db) {
     print_done_if_ok(db.insert(key, path.to_str().unwrap().as_bytes().to_vec()))
 }
 
-fn add_current_path_to_db(key: String, db: sled::Db) -> () {
+fn add_current_path_to_db(key: String, db: sled::Db) {
     match env::current_dir() {
         Ok(current_path) => {
             print_done_if_ok(db.insert(key, current_path.to_str().unwrap().as_bytes().to_vec()))

--- a/src/add/mod.rs
+++ b/src/add/mod.rs
@@ -1,6 +1,6 @@
 use sled::Db;
-use std::path::Path;
 use std::env;
+use std::path::Path;
 
 use diar::util::print_done_if_ok;
 
@@ -10,30 +10,30 @@ pub fn add_favorite(maybe_path_given: Option<&Path>, key: String, db_path: &Path
         Ok(Some(_)) => {
             println!("already exist!");
         }
-        _ => {
-            match maybe_path_given {
-                Some(path) => {
-                    if path.exists() {
-                        add_path_to_db(path, key, db);
-                    } else {
-                        println!("This path does not exist!: {}", path.to_str().unwrap());
-                    }
-                }
-                None => {
-                    add_current_path_to_db(key, db);
+        _ => match maybe_path_given {
+            Some(path) => {
+                if path.exists() {
+                    add_path_to_db(path, key, db);
+                } else {
+                    println!("This path does not exist!: {}", path.to_str().unwrap());
                 }
             }
-        }
+            None => {
+                add_current_path_to_db(key, db);
+            }
+        },
     }
 }
 
 fn add_path_to_db(path: &Path, key: String, db: sled::Db) -> () {
-     print_done_if_ok(db.insert(key, path.to_str().unwrap().as_bytes().to_vec()))
+    print_done_if_ok(db.insert(key, path.to_str().unwrap().as_bytes().to_vec()))
 }
 
 fn add_current_path_to_db(key: String, db: sled::Db) -> () {
     match env::current_dir() {
-        Ok(current_path) => print_done_if_ok(db.insert(key, current_path.to_str().unwrap().as_bytes().to_vec())),
+        Ok(current_path) => {
+            print_done_if_ok(db.insert(key, current_path.to_str().unwrap().as_bytes().to_vec()))
+        }
         Err(e) => println!("{}", e),
     }
 }

--- a/src/clear/mod.rs
+++ b/src/clear/mod.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
 use sled::Db;
+use std::path::Path;
 
 use diar::util::print_done_if_ok;
 
 pub fn clear_db(db_path: &Path) -> () {
     let db = Db::open(db_path).unwrap();
-     print_done_if_ok(db.clear());
+    print_done_if_ok(db.clear());
 }

--- a/src/clear/mod.rs
+++ b/src/clear/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use diar::util::print_done_if_ok;
 
-pub fn clear_db(db_path: &Path) -> () {
+pub fn clear_db(db_path: &Path) {
     let db = Db::open(db_path).unwrap();
     print_done_if_ok(db.clear());
 }

--- a/src/delete/mod.rs
+++ b/src/delete/mod.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use sled::Db;
+use std::path::Path;
 
 use diar::util::print_done_if_ok;
 

--- a/src/jump/mod.rs
+++ b/src/jump/mod.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use diar::types::Favorite;
 use diar::util::get_favorites;
 
-pub fn jump_if_matched(user_input: String, db_path: &Path) -> () {
+pub fn jump_if_matched(user_input: String, db_path: &Path) {
     let db = Db::open(db_path).unwrap();
     let maybe_path_matched = db.get(&user_input);
 
@@ -19,11 +19,11 @@ pub fn jump_if_matched(user_input: String, db_path: &Path) -> () {
     }
 }
 
-fn jump(dest_dir: &Path) -> () {
+fn jump(dest_dir: &Path) {
     println!("{}", dest_dir.to_str().unwrap());
 }
 
-fn suggest(searched: Vec<Favorite>) -> () {
+fn suggest(searched: Vec<Favorite>) {
     println!("Is this what you are jumping?");
     for (key, path) in searched {
         println!("       {} -> {}", key, path);

--- a/src/jump/mod.rs
+++ b/src/jump/mod.rs
@@ -1,8 +1,8 @@
 use sled::Db;
 use std::path::Path;
 
-use diar::util::get_favorites;
 use diar::types::Favorite;
+use diar::util::get_favorites;
 
 pub fn jump_if_matched(user_input: String, db_path: &Path) -> () {
     let db = Db::open(db_path).unwrap();

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use diar::util::get_favorites;
 
-pub fn list_favorites(db_path: &Path) -> () {
+pub fn list_favorites(db_path: &Path) {
     let db = Db::open(db_path).unwrap();
     let iter_db = db.iter();
 

--- a/src/list/mod.rs
+++ b/src/list/mod.rs
@@ -1,14 +1,13 @@
-use std::path::Path;
 use sled::Db;
+use std::path::Path;
 
 use diar::util::get_favorites;
 
 pub fn list_favorites(db_path: &Path) -> () {
     let db = Db::open(db_path).unwrap();
-    let iter_db = db.iter() ;
+    let iter_db = db.iter();
 
     for (key, path) in get_favorites(iter_db) {
         println!("        {} -> {}", key, path);
-
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,6 @@ fn main() {
 
         None => {
             println!("Please give args");
-            return;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,10 @@ fn main() {
         Some(subcommand_name) => match subcommand_name {
             "add" => {
                 if let Some(key) = matches.get_value(subcommand_name, "key") {
-                    match matches.get_value(subcommand_name, "path")
-                    {
-                        Some(path_to_directory) => add::add_favorite(Some(Path::new(&path_to_directory)), key, db_path),
+                    match matches.get_value(subcommand_name, "path") {
+                        Some(path_to_directory) => {
+                            add::add_favorite(Some(Path::new(&path_to_directory)), key, db_path)
+                        }
                         None => add::add_favorite(None, key, db_path),
                     }
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,9 @@ pub fn print_done_if_ok<T, E: Display>(result: Result<T, E>) -> () {
 
 pub fn get_favorites(iter_db: sled::Iter<'_>) -> Vec<Favorite> {
     let mut favorites: Vec<Favorite> = Vec::new();
-    let favorites_utf8 = iter_db.filter(|maybe_favorite| maybe_favorite.is_ok()).map(|ok_favorite| ok_favorite.unwrap());
+    let favorites_utf8 = iter_db
+        .filter(|maybe_favorite| maybe_favorite.is_ok())
+        .map(|ok_favorite| ok_favorite.unwrap());
 
     for converted_favorite in favorites_utf8.map(|favorite_utf8| from_utf8s(favorite_utf8)) {
         if let Some(favorite) = converted_favorite {
@@ -33,4 +35,3 @@ fn from_utf8s(favorite_ivec: (sled::IVec, sled::IVec)) -> Option<Favorite> {
         _ => None,
     }
 }
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use super::types::Favorite;
 
-pub fn print_done_if_ok<T, E: Display>(result: Result<T, E>) -> () {
+pub fn print_done_if_ok<T, E: Display>(result: Result<T, E>) {
     match result {
         Ok(_) => println!("done"),
         Err(e) => println!("{}", e),


### PR DESCRIPTION
I think you should use the tools, `rustfmt` and `clippy` for formatting and analysing(linting) Rust code.

- Format the code according to style guidelines
- Remove the unneeded `unit` return type
    - If you want to return something, you can return `Result` or `Option`.
- Remove the unneeded `return` statement