### PR TITLE
implement new command `diar-jump -p` that jumps to the current project root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A directory favorite tool in Rust.
 
   `diar-jump foo`
 
+  Or, you'd like to jump to the current project root directory:
+
+  `diar-jump -p`
+
   Don't forget the `-`, please wait for the future ;(
 
 - Show the list of added to diar:

--- a/README.md
+++ b/README.md
@@ -44,19 +44,21 @@ A directory favorite tool in Rust.
 
   - `curl -sSf https://static.rust-lang.org/rustup.sh | sh`
 
-- Add the following to your `$HOME.bashrc`
+- Add the following to your `$HOME.bashrc` or others
 
   ```bash
   diar-jump(){
     local selected=$(diar jump $1)
     local flag=0
+
     if [[ -n $selected ]]; then
-      if [ $(echo $selected | grep -e "Is this what you are jumping?") ]; then
+      if [[ $selected =~ "Error:" ]]; then
         diar jump $1
         flag=1
       fi
       if [[ $1 = "-h" ]]; then
         diar jump $1
+        flag=1
       fi
       if [[ $flag -ne 1 ]]; then
         \cd $selected

--- a/src/jump/mod.rs
+++ b/src/jump/mod.rs
@@ -1,12 +1,20 @@
 use sled::Db;
 use std::path::Path;
+use std::process::Command;
 
-use diar::types::Favorite;
+use diar::types::{Favorite, GetProjectRootError, JumpTo};
 use diar::util::get_favorites;
 
-pub fn jump_if_matched(user_input: String, db_path: &Path) {
+pub fn jump_to(to: JumpTo, db_path: &Path) {
     let db = Db::open(db_path).unwrap();
-    let maybe_path_matched = db.get(&user_input);
+    match to {
+        JumpTo::Key(key) => jump_to_key(&key, db),
+        JumpTo::ProjectRoot => jump_to_project_root(),
+    }
+}
+
+fn jump_to_key(key: &str, db: sled::Db) {
+    let maybe_path_matched = db.get(key);
 
     match maybe_path_matched {
         Ok(Some(path)) => {
@@ -14,7 +22,40 @@ pub fn jump_if_matched(user_input: String, db_path: &Path) {
             jump(Path::new(&path_string));
         }
         _ => {
-            suggest(search(&user_input, db));
+            suggest(key, search(key, db));
+        }
+    }
+}
+
+fn get_project_root_path() -> Result<String, GetProjectRootError> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg("git rev-parse --show-toplevel")
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(String::from_utf8(output.stdout)
+                    .unwrap()
+                    .trim_end()
+                    .to_string())
+            } else {
+                Err(GetProjectRootError::DotGitNotFound)
+            }
+        }
+        Err(_) => Err(GetProjectRootError::GitCommandNotFound),
+    }
+}
+
+fn jump_to_project_root() {
+    match get_project_root_path() {
+        Ok(path_string) => jump(Path::new(&path_string)),
+        Err(GetProjectRootError::DotGitNotFound) => {
+            println!("Error: .git directory not found.");
+        }
+        Err(GetProjectRootError::GitCommandNotFound) => {
+            println!("Error: Command 'git' not found.");
         }
     }
 }
@@ -23,7 +64,8 @@ fn jump(dest_dir: &Path) {
     println!("{}", dest_dir.to_str().unwrap());
 }
 
-fn suggest(searched: Vec<Favorite>) {
+fn suggest(input: &str, searched: Vec<Favorite>) {
+    println!("Error: Key '{}' not found.\n", input);
     println!("Is this what you are jumping?");
     for (key, path) in searched {
         println!("       {} -> {}", key, path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate sled;
 
 use clap::ArgMatches;
 use clap::{App, Arg, SubCommand};
+use diar::types::JumpTo;
 use dirs::home_dir;
 use std::path::Path;
 
@@ -66,12 +67,17 @@ fn main() {
         .subcommand(SubCommand::with_name("list").about("List favorite directories"))
         .subcommand(
             SubCommand::with_name("jump")
-                .about("Jump to your favorite directory")
+                .about("Jump to your favorite directory or root firectory of the project")
                 .arg(
                     Arg::with_name("key")
                         .help("favorite dirs key")
-                        .takes_value(true)
-                        .required(true),
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("project-root")
+                        .help("The current project root directory")
+                        .long("project-root")
+                        .short("p"),
                 ),
         )
         .subcommand(SubCommand::with_name("clear").about("Delete all favorite directories."));
@@ -108,8 +114,14 @@ fn main() {
             "list" => list::list_favorites(db_path),
 
             "jump" => {
-                if let Some(key) = matches.get_value(subcommand_name, "key") {
-                    jump::jump_if_matched(key, db_path);
+                if let Some(subcommand_matches) = matches.subcommand_matches(subcommand_name) {
+                    if subcommand_matches.is_present("project-root") {
+                        jump::jump_to(JumpTo::ProjectRoot, db_path);
+                    } else {
+                        if let Some(key) = matches.get_value(subcommand_name, "key") {
+                            jump::jump_to(JumpTo::Key(key), db_path);
+                        }
+                    }
                 }
             }
             "clear" => clear::clear_db(db_path),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,1 +1,11 @@
 pub type Favorite = (String, String);
+
+pub enum JumpTo {
+    Key(String),
+    ProjectRoot,
+}
+
+pub enum GetProjectRootError {
+    GitCommandNotFound,
+    DotGitNotFound,
+}


### PR DESCRIPTION
- implement `diar-jump -p` command
- change the function that users write to `.bashrc`
- add a description of `diar-jump -p` command
- fix something